### PR TITLE
Recursive heuristics

### DIFF
--- a/0_control_params.R
+++ b/0_control_params.R
@@ -1,14 +1,18 @@
 # usage:
-# change the 9 sets of parameters below and set the local julia and R paths (sorry).
+# change the 10 sets of parameters below and set the local julia and R paths (sorry).
 # then run from console with:
 
-#    [Rscript path] 0_control_params.R
+#    [Rscript path] 0_control_params.R [r XOR j XOR nothing]
+
+# arg = r if you just want it to sim networks in R, arg = j if you just want to
+# analyze the nets in julia, arg = blank if you want both / don't know what
+# i'm talking about.
 
 # output is "results.csv".
 
-seed   =  1440 + 1:2         # i like to do current time.  what you add is nreps
+seed   =  9321
 nnet   =  200                # number of networks per scenario
-ntaxa  =  c(4, 6)            # number of taxa per network
+ntaxa  =  c(4, 6, 8)         # number of taxa per network
 lambda =  c(0.1, 0.3, 1, 3)  # speciation rate, in CUs
 mu     =  c(0.1, 0.9)        # extinction rate, as a % of lambda
 nu     =    0.5              # hybridization rate, as as % of lambda
@@ -17,16 +21,32 @@ d_0    =  c(0.1, 0.3, 0.6)*2 # forbid hybridizations between lineages more than 
 model  =  1                  # ssa = 0, gsa = 1.  see hartmann wong stadler 2010
 ngt    =  200                # number of gene trees per quartet
 
-#julia  = "/u/f/o/fogg/julia-1.8.0/bin/julia" # sorry
-julia  = "/u/f/o/fogg/julia-1.8.0/bin/julia --threads 128" # sorry
+ncores_julia = 8
+ncores_R     = 16 # just for looping over scenarios.  not for looping over nets
+
+simulate_nets_in_R = FALSE
+analyze_nets_in_julia = FALSE
+
+julia  = "/u/f/o/fogg/julia-1.8.0/bin/julia"
 R      = "Rscript"
 
-timeout = "4h" # i don't know if i've ever seen it work in a time > 13min but <20min
+#on john's machine: julia = "/home/john/julia-1.7.3/bin/julia"
+#on franklin00: julia = "/u/f/o/fogg/julia-1.8.0/bin/julia"
+
+timeout = "4h" # i don't know if i've ever seen it work in a time >13min but <20min
 delete1 = FALSE # whether to simulate up to N+1 taxa, then delete 1 later
 
-#on john's machine: julia = "/home/john/julia-1.7.3/bin/julia"
+arg = commandArgs(trailingOnly=TRUE)
+if(length(arg) > 1) error("too many args")
+if(is.na(arg[1])) arg == 'rj'
+if(arg=='r') simulate_nets_in_R = TRUE # if false, you need to provide the nets yourself
+if(arg=='j') analyze_nets_in_julia = TRUE
+if(arg=='rj') {
+  simulate_nets_in_R = TRUE
+  analyze_nets_in_julia = TRUE
+}
 
-# R will expand.grid the 9 parameter sets and ask SiPhyNetworks to simulate
+# R will expand.grid the 10 parameter sets and ask SiPhyNetworks to simulate
 # under every combination thereof ("scenario"), then pass the simulated networks to other
 # julia + R scripts for further analysis.  the output is "results.csv": it has
 # one row for every scenario, and summary statistics about each one.
@@ -84,19 +104,23 @@ scenarios =
 ###
 
 startingdir = getwd()
+print(startingdir)
 try(system("rm results.csv"), TRUE)
 
-script1 = file.path(startingdir, "1_sim_networks.R")
-script2 = file.path(startingdir, "2_extract_quartet_subnetworks.jl")
-script3 = file.path(startingdir, "3_summarize_findings.R")
+script1 = paste0('\"', file.path(startingdir, "1_sim_networks.R"),                 '\"')
+script2 = paste0('\"', file.path(startingdir, "2_extract_quartet_subnetworks.jl"), '\"')
+script3 = paste0(      file.path(startingdir, "3_summarize_findings.R")                )
+
 
 parallel_job = function(i) {
   
   jobdir = paste0("job", i)
   tic(jobdir)
   cat(paste('start', jobdir, '\n'))
-  unlink(jobdir, recursive = TRUE)
-  dir.create(jobdir)
+  if(simulate_nets_in_R) { # then we need to clean the directory.  o/w leave alone
+    unlink(jobdir, recursive = TRUE)
+    dir.create(jobdir)
+  }
   setwd(jobdir)
   
   # parameters for siphynetwork
@@ -105,16 +129,21 @@ parallel_job = function(i) {
   params1 = paste(unlist(params1), collapse=" ")
   
   # parameters for phylocoalsimulations
-  params2 = scenarios[i, 11]
-  params2 = paste(unlist(params2), as.numeric(delete1), collapse=" ")
+  params2 = scenarios[i, c(1,11)]
+  params2 = paste(unlist(params2), collapse=" ")
+  params2 = paste(params2, as.numeric(delete1), collapse=" ")
   
-  command1 = paste("timeout", timeout, R,     script1, params1, sep=" ")
-  command2 = paste("timeout", timeout, julia, script2, params2, sep=" ")
+  command1 = paste("timeout", timeout, R,                                script1, params1, sep=" ")
+  command2 = paste("timeout", timeout, julia, "--threads", ncores_julia, script2, params2, sep=" ")
   
-  cat(paste(jobdir, command1, "\n"))
-  system(command1)
-  cat(paste(jobdir, command2, "\n"))
-  system(command2)
+  if(simulate_nets_in_R) {
+    cat(paste(jobdir, command1, "\n"))
+    system(command1)
+  }
+  if(analyze_nets_in_julia) {
+    cat(paste(jobdir, command2, "\n"))
+    system(command2)
+  }
   
   setwd(startingdir)
   cat('finish', jobdir, '\n')
@@ -144,9 +173,8 @@ serial_job = function(i) {
 }
 
 
-numCores = 1
-results_parallel = mclapply(X=1:nrow(scenarios), FUN=parallel_job, mc.cores = numCores)
-results_serial   =   lapply(X=1:nrow(scenarios), FUN=  serial_job                     )
+if(TRUE)                  results_parallel = mclapply(X=1:nrow(scenarios), FUN=parallel_job, mc.cores = ncores_R)
+if(analyze_nets_in_julia) results_serial   =   lapply(X=1:nrow(scenarios), FUN=  serial_job                     )
 
 
 results = results_serial[[1]]

--- a/1_sim_networks.R
+++ b/1_sim_networks.R
@@ -18,9 +18,9 @@ model  = args[10] # 0 for ssa and 1 for gsa... see (e.g.) hartmann wong stadler 
 
 ###
 
-library(Rcpp, lib.loc=.libPaths()[2]) # force to load from local library on franklinXX (sorry)
-library(SiPhyNetwork, lib.loc=.libPaths()[1])
-library(ape, lib.loc=.libPaths()[1])
+library(Rcpp)
+library(SiPhyNetwork)
+library(ape)
 
 ###
 
@@ -52,6 +52,7 @@ while(length(ssa_nets_full) < nnet) {
       nu            = nu,
       hybprops      = hybrid_proportions,
       hyb.inher.fxn = inheritance.fxn,
+      hyb.rate.fxn  = hybrid_success_prob,
       complete      = FALSE # do not return extinct taxa
     )
   }
@@ -65,6 +66,7 @@ while(length(ssa_nets_full) < nnet) {
       nu            = nu,
       hybprops      = hybrid_proportions,
       hyb.inher.fxn = inheritance.fxn,
+      hyb.rate.fxn  = hybrid_success_prob,
       complete      = FALSE # do not return extinct taxa
     )
   }

--- a/2_extract_quartet_subnetworks.jl
+++ b/2_extract_quartet_subnetworks.jl
@@ -20,15 +20,15 @@ using CSV
 include("find_blobs_and_degree.jl")
 include("find_3blobqCF.jl")
 
-ngt = parse(Int64, ARGS[1])
-delete1 = parse(Int8, ARGS[2])
+seed    = parse(Int64, ARGS[1])
+ngt     = parse(Int64, ARGS[2])
+delete1 = parse(Int8,  ARGS[3])
 
 if !(delete1 == 0 || delete1 == 1)
 	print("delete1 not 0 or 1, interpreting as 0")
 	delete1 = 0
 end
 
-seed = 9 # nine rings for men
 Random.seed!(seed)
 
 #need to loop over trees
@@ -46,7 +46,7 @@ readTopologyFailures = repeat("", N)
 
 function analyzeTreeFile(treefile::String, treenum::Int64)
 
-	print(treefile * '\n')
+	#print(treefile * '\n')
 
 	m = match(r"sim(\d+)\.tree", treefile)
 	sim_num = parse(Int16, m.captures[1])
@@ -99,9 +99,9 @@ function analyzeTreeFile(treefile::String, treenum::Int64)
 	)
 
 	Threads.@threads for j = 1:nquartets
-		print(treefile * string(quartets[j]) * '\n')
+		#print(treefile * string(quartets[j]) * '\n')
 		dft[j,2] = string(quartets[j])
-		dft[j,3:end] = analyzeQuartet(quartets[j], taxa, tree)[1,:] # each quartet returns a DataFrame with one row and no sim_num
+		dft[j,3:end] = analyzeQuartet(quartets[j], taxa, tree; seed=seed)[1,:] # each quartet returns a DataFrame with one row and no sim_num
 	end
 
 	return(dft)

--- a/find_3blobqCF.jl
+++ b/find_3blobqCF.jl
@@ -213,16 +213,25 @@ function quartettype_qCF(net::HybridNetwork,
       end
       flag_class = (h_true != h_used)
       # custom function to extract unrooted displayed tree topologies
-      dtree = displayed_unrootedtreetopologies!(net2)
+      dsplit = displayed_splits!(net2, taxonlist)
+      #dtree = displayed_unrootedtreetopologies!(net2)
       mat = BitMatrix(undef, (0,4)) # initialize: 1 row per split
-      for tree in dtree
-          split = treesplit(tree, taxonlist)
-          oldsplit = any( x-> isequal_split(split, x), eachrow(mat))
-          if !oldsplit
-            mat = [mat; split']
-          end
-          size(mat,1) >= 3 && break
+      print("mat="*string(mat)*"\n")
+      for split in dsplit
+      	print("split=" *string(split )*"\n")
+	print("split'="*string(split')*"\n")
+      	mat = [mat; split']
+	print("mat=" * string(mat) * "\n")
       end
+      print("mat=" * string(mat) * "\n")
+      #for tree in dtree
+      #    split = treesplit(tree, taxonlist)
+      #    oldsplit = any( x-> isequal_split(split, x), eachrow(mat))
+      #    if !oldsplit
+      #      mat = [mat; split']
+      #    end
+      #    size(mat,1) >= 3 && break
+      #end
       nsplits = size(mat,1)
       if nsplits == 1
         flag_class || @error "found only 1 split on network with a 4-blob, yet no underestimation. ???"
@@ -387,7 +396,7 @@ AB|CD and AC|BD but not AD|BC.)
 """
 function displayed_splits!(net, taxonlist)
   splits = []
-  displayed_splits!(splits, net, taxonlist)
+  splits = displayed_splits!(splits, net, taxonlist)
   return(splits)
 end
 function displayed_splits!(splits, net, taxonlist)
@@ -435,6 +444,7 @@ function lowesthybrid(net)
     i -= 1
     nn = net.nodes_changed[i]
   end
+  return(nn)
 end
 
 """

--- a/find_3blobqCF.jl
+++ b/find_3blobqCF.jl
@@ -216,14 +216,14 @@ function quartettype_qCF(net::HybridNetwork,
       dsplit = displayed_splits!(net2, taxonlist)
       #dtree = displayed_unrootedtreetopologies!(net2)
       mat = BitMatrix(undef, (0,4)) # initialize: 1 row per split
-      print("mat="*string(mat)*"\n")
+      #print("mat="*string(mat)*"\n")
       for split in dsplit
-      	print("split=" *string(split )*"\n")
-	print("split'="*string(split')*"\n")
+      	#print("split=" *string(split )*"\n")
+	#print("split'="*string(split')*"\n")
       	mat = [mat; split']
-	print("mat=" * string(mat) * "\n")
+	#print("mat=" * string(mat) * "\n")
       end
-      print("mat=" * string(mat) * "\n")
+      #print("mat=" * string(mat) * "\n")
       #for tree in dtree
       #    split = treesplit(tree, taxonlist)
       #    oldsplit = any( x-> isequal_split(split, x), eachrow(mat))
@@ -233,6 +233,8 @@ function quartettype_qCF(net::HybridNetwork,
       #    size(mat,1) >= 3 && break
       #end
       nsplits = size(mat,1)
+      #print(size(mat,1))
+      #print(size(mat,2))
       if nsplits == 1
         flag_class || @error "found only 1 split on network with a 4-blob, yet no underestimation. ???"
         @error "found only 1 split on 4-blob: flag is true and there's an underestimation for sure"
@@ -404,6 +406,7 @@ function displayed_splits!(splits, net, taxonlist)
   unroot_shrink!(net) # splits are invariant to root and 3-cycles, so "flatten" them out
   if net.numHybrids==0 # if it's a tree...
     newsplit = treesplit(net,taxonlist) # ...then grab the split
+    splits==[] && push!(splits, newsplit)
     all(isequal_split(newsplit, x) for x in splits) || push!(splits, newsplit)
     return(splits)
   else # if it's not a tree...
@@ -411,6 +414,7 @@ function displayed_splits!(splits, net, taxonlist)
     bdegree = blob_degrees[2]
     if all(bdegree .< 4) # if the network has no 4-blob, then it's of class 1:
       newsplit = treesplit(net,taxonlist) # get the one split
+      splits==[] && push!(splits, newsplit)
       all(isequal_split(newsplit, x) for x in splits) || push!(splits, newsplit) 
       return(splits)
       # (use treesplit, even though net is not a tree.)

--- a/find_3blobqCF.jl
+++ b/find_3blobqCF.jl
@@ -212,29 +212,13 @@ function quartettype_qCF(net::HybridNetwork,
         end
       end
       flag_class = (h_true != h_used)
-      # custom function to extract unrooted displayed tree topologies
+      # custom function to extract displayed splits
       dsplit = displayed_splits!(net2, taxonlist)
-      #dtree = displayed_unrootedtreetopologies!(net2)
       mat = BitMatrix(undef, (0,4)) # initialize: 1 row per split
-      #print("mat="*string(mat)*"\n")
       for split in dsplit
-      	#print("split=" *string(split )*"\n")
-	#print("split'="*string(split')*"\n")
       	mat = [mat; split']
-	#print("mat=" * string(mat) * "\n")
       end
-      #print("mat=" * string(mat) * "\n")
-      #for tree in dtree
-      #    split = treesplit(tree, taxonlist)
-      #    oldsplit = any( x-> isequal_split(split, x), eachrow(mat))
-      #    if !oldsplit
-      #      mat = [mat; split']
-      #    end
-      #    size(mat,1) >= 3 && break
-      #end
       nsplits = size(mat,1)
-      #print(size(mat,1))
-      #print(size(mat,2))
       if nsplits == 1
         flag_class || @error "found only 1 split on network with a 4-blob, yet no underestimation. ???"
         @error "found only 1 split on 4-blob: flag is true and there's an underestimation for sure"
@@ -426,16 +410,6 @@ function displayed_splits!(splits, net, taxonlist)
       displayed_splits!(splits, net,    taxonlist) # and then recursion.
       displayed_splits!(splits, netmin, taxonlist)
       return(splits)
-    end
-  end
-end
-function remove_redundant_splits!(splits)
-  for i in length(splits):-1:1
-    thissplit    = splits[i                     ]
-    pastsplits   = splits[  (i+1):length(splits)]
-    oldsplit = any( x-> isequal_split(thissplit, x), each(pastsplits))
-    if oldsplit
-      deleteat!(splits, i)
     end
   end
 end


### PR DESCRIPTION
obtains the set of displayed splits on a quartet network faster.  is faster because it usually avoids evaluating all of the network's displayed trees. there are 2^n displayed trees on a network with n hybrid nodes.  avoids evaluating all of the network's displayed trees by 1) recognizing that quartet networks with a 3_2 blob have only one displayed tree, regardless of how many hybrid nodes they have, and 2) recognizing that we can often "reveal" "latent" 3_2 blobs by removing hybrid nodes from the bottom up.